### PR TITLE
Adding of files for NLP analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 API_KEY
 SEARCH_ENGINE_ID
+.env

--- a/love_in_paradise/server/analysis/evidence_alignment.py
+++ b/love_in_paradise/server/analysis/evidence_alignment.py
@@ -1,0 +1,39 @@
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+import torch
+
+
+model = AutoModelForSequenceClassification.from_pretrained(
+    "cross-encoder/nli-deberta-v3-small"
+)
+tokenizer = AutoTokenizer.from_pretrained("cross-encoder/nli-deberta-v3-small")
+
+
+class EvidenceAlignment:
+    """
+    This class focuses on checking if facts on the evidence are consistent with the claim.
+
+    Some uses are calculation for entailment, contractiction, and neutrality.
+    """
+
+    def calculate_entailment(self, claim, sentences):
+        sentence_combinations = [[claim, sentence] for sentence in sentences]
+
+        features = tokenizer(
+            sentence_combinations,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        model.eval()
+        with torch.no_grad():
+            scores = model(**features).logits
+            label_mapping = ["contradiction", "entailment", "neutral"]
+            labels = []
+            max_scores = scores.argmax(dim=1)
+            for i in range(len(scores)):
+                top_score = max_scores[i]
+                score = scores[i][top_score]
+                label = label_mapping[top_score]
+                labels.append((label, score))
+            return labels

--- a/love_in_paradise/server/analysis/open_info_extraction.py
+++ b/love_in_paradise/server/analysis/open_info_extraction.py
@@ -1,0 +1,32 @@
+from stanza.server import CoreNLPClient, StartServer
+
+"""
+import stanza
+stanza.install_corenlp()
+"""
+
+PROPERTIES = {
+    "openie.resolve_coref": True,
+}
+
+
+class OpenInformationExtraction:
+    """
+    Uses Stanza/Stanford OpenIE for extracting relations from text sentences.
+    """
+
+    triples = []
+
+    def generate_triples(self, text):
+        # Returns a triple for each sentence
+        with CoreNLPClient(
+            annotators=["openie", "coref"],
+            start_server=StartServer.TRY_START,
+            properties=PROPERTIES,
+        ) as client:
+            annotation = client.annotate(text)
+            for sentence in annotation.sentence:
+                for data in sentence.openieTriple:
+                    triple = (data.subject, data.relation, data.object)
+                    print("|-", triple)
+                    self.triples.append(triple)

--- a/love_in_paradise/server/analysis/rebel_extractor.py
+++ b/love_in_paradise/server/analysis/rebel_extractor.py
@@ -1,0 +1,40 @@
+from transformers import pipeline
+import spacy
+import rebel_spacy_component
+
+
+class REBELExtractor:
+    """
+    Uses REBEL-large model for relation extraction.
+    More resource intensive than Stanford OpenIE.
+    """
+
+    def __init__(self, nlp=None):
+        if nlp is None:
+            self.nlp = spacy.load("en_core_web_sm")
+        else:
+            self.nlp = nlp
+
+        self.nlp.add_pipe(
+            "rebel",
+            after="senter",
+            config={
+                # "device": 0,  # Number of the GPU, -1 if want to use CPU
+                "model_name": "Babelscape/rebel-large",
+            },  # Model used, will default to 'Babelscape/rebel-large' if not given
+        )
+
+    def extract_relations(self, sentence):
+        doc = self.nlp(sentence)
+        # doc_list = self.nlp.pipe([input_sentence])
+        triples = []
+        for value, rel_dict in doc._.rel.items():
+            print(f"{value}: {rel_dict}")
+            triples.append(
+                (
+                    rel_dict["head_span"].text,
+                    rel_dict["relation"],
+                    rel_dict["tail_span"].text,
+                )
+            )
+        return triples

--- a/love_in_paradise/server/analysis/rebel_spacy_component.py
+++ b/love_in_paradise/server/analysis/rebel_spacy_component.py
@@ -1,0 +1,267 @@
+# Taken from https://github.com/Babelscape/rebel/blob/main/spacy_component.py
+from spacy import Language, util
+from spacy.tokens import Doc, Span
+from transformers import pipeline
+from typing import List
+import re
+
+
+def extract_triplets(text: str) -> List[str]:
+    """
+    parses the text to triplets
+    1. Split the text into tokens
+    2. If the token is <triplet>, <subj>, or <obj>, then set the current variable to the appropriate value
+    3. If the token is not one of the above, then append it to the appropriate variable
+    4. If the current variable is <subj>, then append the triplet to the list of triplets
+
+    :param text: str - the text to be parsed
+    :type text: str
+    :return: A list of dictionaries.
+    """
+
+    triplets = []
+    relation, subject, relation, object_ = "", "", "", ""
+    text = text.strip()
+    current = "x"
+
+    for token in (
+        text.replace("<s>", "").replace("<pad>", "").replace("</s>", "").split()
+    ):
+
+        if token == "<triplet>":
+
+            current = "t"
+
+            if relation != "":
+
+                triplets.append(
+                    {
+                        "head": subject.strip(),
+                        "type": relation.strip(),
+                        "tail": object_.strip(),
+                    }
+                )
+                relation = ""
+
+            subject = ""
+
+        elif token == "<subj>":
+
+            current = "s"
+
+            if relation != "":
+
+                triplets.append(
+                    {
+                        "head": subject.strip(),
+                        "type": relation.strip(),
+                        "tail": object_.strip(),
+                    }
+                )
+
+            object_ = ""
+
+        elif token == "<obj>":
+
+            current = "o"
+            relation = ""
+
+        else:
+
+            if current == "t":
+
+                subject += " " + token
+
+            elif current == "s":
+
+                object_ += " " + token
+
+            elif current == "o":
+
+                relation += " " + token
+
+    if (subject != "") and (relation != "") and (object_ != ""):
+
+        triplets.append(
+            {"head": subject.strip(), "type": relation.strip(), "tail": object_.strip()}
+        )
+
+    return triplets
+
+
+@Language.factory(
+    "rebel",
+    requires=["doc.sents"],
+    assigns=["doc._.rel"],
+    default_config={
+        "model_name": "Babelscape/rebel-large",
+        "device": 0,
+    },
+)
+class RebelComponent:
+
+    def __init__(
+        self,
+        nlp,
+        name,
+        model_name: str,
+        device: int,
+    ):
+
+        assert model_name is not None, ""
+
+        self.triplet_extractor = pipeline(
+            "text2text-generation",
+            model=model_name,
+            tokenizer=model_name,
+            device=device,
+        )
+
+        # Register custom extension on the Doc
+        if not Doc.has_extension("rel"):
+
+            Doc.set_extension("rel", default={})
+
+    def _generate_triplets(self, sents: List[Span]) -> List[List[dict]]:
+        """
+        1. We pass the text of the sentence to the triplet extractor.
+        2. The triplet extractor returns a list of dictionaries.
+        3. We extract the token ids from the dictionaries.
+        4. We decode the token ids into text.
+        5. We extract the triplets from the text.
+        6. We return the triplets.
+
+        The triplet extractor is a model that takes a sentence as input and returns a list of dictionaries.
+        Each dictionary contains the token ids of the extracted triplets.
+
+        The token ids are the numbers that represent the words in the sentence.
+        For example, the token id of the word "the" is 2.
+
+        The token ids are decoded into text using the tokenizer.
+        The tokenizer is a model that takes a list of token ids as input and returns a list of words.
+
+        :param sents: List[Span]
+        :type sents: List[Span]
+        :return: A list of lists of dicts.
+        """
+
+        output_ids = self.triplet_extractor(
+            [sent.text for sent in sents], return_tensors=True, return_text=False
+        )  # [0]["generated_token_ids"]
+        extracted_texts = self.triplet_extractor.tokenizer.batch_decode(
+            [out["generated_token_ids"] for out in output_ids]
+        )
+        extracted_triplets = []
+
+        for text in extracted_texts:
+
+            extracted_triplets.extend(extract_triplets(text))
+
+        return extracted_triplets
+
+    def set_annotations(self, doc: Doc, triplets: List[dict]):
+        """
+        The function takes a spacy Doc object and a list of triplets (dictionaries) as input.
+        For each triplet, it finds the substring in the Doc object that matches the head and tail of the triplet.
+        It then creates a spacy span object for each of the head and tail.
+        Finally, it creates a dictionary of the relation type, head span and tail span and adds it to the Doc object
+
+        :param doc: the spacy Doc object
+        :type doc: Doc
+        :param triplets: List[dict]
+        :type triplets: List[dict]
+        """
+
+        text = doc.text.lower()
+
+        for triplet in triplets:
+
+            if triplet["head"] == triplet["tail"]:
+
+                continue
+
+            head_match = re.search(
+                r"\b" + re.escape(triplet["head"].lower()) + r"\b", text
+            )
+            if head_match:
+                head_index = head_match.start()
+            else:
+                head_index = text.find(triplet["head"].lower())
+
+            tail_match = re.search(
+                r"\b" + re.escape(triplet["tail"].lower()) + r"\b", text
+            )
+            if tail_match:
+                tail_index = tail_match.start()
+            else:
+                tail_index = text.find(triplet["tail"].lower())
+
+            if (head_index == -1) or (tail_index == -1):
+
+                continue
+
+            head_span = doc.char_span(
+                head_index, head_index + len(triplet["head"]), alignment_mode="expand"
+            )
+            tail_span = doc.char_span(
+                tail_index, tail_index + len(triplet["tail"]), alignment_mode="expand"
+            )
+
+            try:
+
+                offset = (head_span.start, tail_span.start)
+
+            except AttributeError:
+
+                continue
+
+            if offset not in doc._.rel:
+
+                doc._.rel[offset] = {
+                    "relation": triplet["type"],
+                    "head_span": head_span,
+                    "tail_span": tail_span,
+                }
+
+    def __call__(self, doc: Doc) -> Doc:
+        """
+        The function takes a doc object and returns a doc object
+
+        :param doc: Doc
+        :type doc: Doc
+        :return: A Doc object with the sentence triplets added as annotations.
+        """
+
+        sentence_triplets = self._generate_triplets(doc.sents)
+        self.set_annotations(doc, sentence_triplets)
+
+        return doc
+
+    def pipe(self, stream, batch_size=128):
+        """
+        It takes a stream of documents, and for each document,
+        it generates a list of sentence triplets,
+        and then sets the annotations for each sentence in the document
+
+        :param stream: a generator of Doc objects
+        :param batch_size: The number of documents to process at a time, defaults to 128 (optional)
+        """
+
+        for docs in util.minibatch(stream, size=batch_size):
+
+            sents = []
+
+            for doc in docs:
+
+                sents += doc.sents
+
+            sentence_triplets = self._generate_triplets(sents)
+            index = 0
+
+            for doc in docs:
+
+                n_sent = len(list(doc.sents))
+                self.set_annotations(doc, sentence_triplets[index : index + n_sent])
+                index += n_sent
+
+                yield doc

--- a/love_in_paradise/server/analysis/sentence_similarity.py
+++ b/love_in_paradise/server/analysis/sentence_similarity.py
@@ -1,21 +1,17 @@
-from nltk.tokenize import sent_tokenize
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.util import cos_sim
-
-
-"""
-This class needs punkt_tab to be installed first
-Run the below code in the Python interpreter:
-    import nltk
-    nltk.download("punkt_tab")
-"""
 
 CUTTOFF_SCORE = 0.25
 
 
 class SentenceSimilarity:
-    def __init__(self):
+    """
+    For searching sentences similar to the claim in a document.
+    """
+
+    def __init__(self, nlp):
         self.model = SentenceTransformer("distiluse-base-multilingual-cased-v1")
+        self.nlp = nlp  # Spacy NLP model
 
     # Set and encode main sentence that will be used for comparison.
     def set_main_sentence(self, main_sentence):
@@ -25,7 +21,8 @@ class SentenceSimilarity:
     def find_similar_sentences(self, content):
 
         # Separate content into list of sentences
-        tokenized_sentences = sent_tokenize(content)
+        doc = self.nlp(content)
+        tokenized_sentences = [sent.text for sent in doc.sents]
 
         # Encode sentences
         ts_encoding = self.model.encode(tokenized_sentences)

--- a/love_in_paradise/server/analysis/text_preprocessing.py
+++ b/love_in_paradise/server/analysis/text_preprocessing.py
@@ -1,0 +1,3 @@
+class TextPreprocessing:
+    pass
+    # TODO: text cleanup, coreference resolution, segmentation, sentence simplification

--- a/love_in_paradise/server/analysis/utils.py
+++ b/love_in_paradise/server/analysis/utils.py
@@ -1,0 +1,32 @@
+import networkx as nx
+from pyvis.network import Network
+
+
+def get_relevant_triples(main_triple, triples):
+    subject = main_triple[0]
+    results = []
+    for tri in triples:
+        if subject in tri:
+            results.append(tri)
+    # print("Results:", results)
+    return results
+
+
+def triple_to_sentence(triple):
+    return " ".join(triple)
+
+
+# Create Networkx Knowledge Graph and visualization on html
+def generate_graph(list_triples, filename="graph.html"):
+    knowledge_graph = nx.Graph()
+    net = Network()
+    for triple in list_triples:
+
+        knowledge_graph.add_nodes_from([triple[0], triple[2]])
+        knowledge_graph.add_edge(triple[0], triple[2], relation=triple[1])
+
+        net.add_node(triple[0])
+        net.add_node(triple[2])
+        net.add_edge(triple[0], triple[2], title=triple[1])
+    net.write_html(filename, notebook=False, open_browser=False)
+    return knowledge_graph

--- a/love_in_paradise/server/llm/fact_checker_agent.py
+++ b/love_in_paradise/server/llm/fact_checker_agent.py
@@ -1,0 +1,96 @@
+import requests
+import json
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+
+SYSTEM_PROMPT = f"""Instructions:\
+1. You are a fact checker designed to evaluate claims based on real world sources.
+2. The user will provide you with a CLAIM and relevant FACTS listed in an array.
+3. Based on the FACTS, assess the factual accuracy of the CLAIM.
+4. Before presenting your conclusion, think through the process step-by-step. 
+   Include a summary of the key points from the FACTS as part of your justification.
+5. If the FACTS allows you to confidently make a decision, output the verdict and 
+   your justification in the following format:
+   {{
+     "verdict": "VERDICT_LABEL_HERE",
+     "justification": "JUSTIFICATION_HERE"
+   }}
+6. The verdict should be a succinct label of one or two words such as "True", "False", "Partially True", or other more fitting labels.
+   If the FACTS supplied is not enough to form a confident conclusion, output the verdict as "Not enough information".
+7. The justification should be a paragraph composed of any number of sentences provided they are clear enough to understand.
+   It should also supply which URL each derived reasoning was made from.
+"""
+
+_KNOWLEDGE_HERE = "[KNOWLEDGE]"
+_CLAIM_HERE = "[CLAIM]"
+
+user_prompt = f"""\
+KNOWLEDGE:
+{_KNOWLEDGE_HERE}
+
+CLAIM:
+{_CLAIM_HERE}
+"""
+
+
+class FactCheckerAgent:
+    """
+    This uses an API request to an LLM for fact-checking.
+
+    Knowledge or context is directly applied to the prompt for comparison with the claim.
+    Automatically generates a verdict and justification as dictionary with "verdict" and
+    "justification" keys.
+    """
+
+    def __init__(self, knowledge, claim):
+        self.user_prompt = user_prompt.replace(_KNOWLEDGE_HERE, knowledge).replace(
+            _CLAIM_HERE, claim
+        )
+
+    # Prints json reponse
+    def verify(self):
+        response = requests.post(
+            url="https://openrouter.ai/api/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+                "X-Title": "Deception Detector",  # Optional. Site title for rankings on openrouter.ai.
+                # "HTTP-Referer": "<YOUR_SITE_URL>", # Optional. Site URL for rankings on openrouter.ai.
+            },
+            data=json.dumps(
+                {
+                    "model": "openai/gpt-oss-20b:free",
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": SYSTEM_PROMPT,
+                        },
+                        {
+                            "role": "user",
+                            "content": self.user_prompt,
+                        },
+                    ],
+                }
+            ),
+        )
+        if response.status_code == 200:
+            try:
+                data = response.json()["choices"][0]["message"]
+                vnj = json.loads(data["content"])
+            except:
+                print("Error: Data not found")
+                print(json.dumps(response.json(), indent=2))
+                return
+            # print(f"Verdict: {vnj["verdict"]} \n")
+            # print(f"Justification: {vnj["justification"]}")
+            return (vnj["verdict"], vnj["justification"])
+        # print(json.dumps(response.json(), indent=2))
+
+    def check_api(self):
+        response = requests.get(
+            url="https://openrouter.ai/api/v1/key",
+            headers={"Authorization": f"Bearer {OPENROUTER_API_KEY}"},
+        )
+        print(json.dumps(response.json(), indent=2))


### PR DESCRIPTION
Added a few files needed for processing and analysis.
### Currently:
- Open Information Extraction for extracting triples (subject-predicate-object) using Stanford OpenIE
- Alternative info extraction using REBEL model
    - not as detailed, extracts only people and orgs
- Evidence and claim alignment using Cross-Encoder NLI
- LLM for verdict and justification text generation (OpenRouter API)

### Not yet implemented/unfinished:
- Articles' content text preprocessing
- Custom data classes for triple/evidence
- Better retrieval of relevant evidence
- Aggregation of evidence and scores
- Confidence scoring
- Verdict decision logic
- Filipino language support
- Testing of system using datasets